### PR TITLE
Allow backup_timer to be specified as a double instead of int

### DIFF
--- a/src/main/java/com/feed_the_beast/ftbu/config/FTBUConfigBackups.java
+++ b/src/main/java/com/feed_the_beast/ftbu/config/FTBUConfigBackups.java
@@ -34,6 +34,6 @@ public class FTBUConfigBackups
 
     public static long backupMillis()
     {
-        return (long) (backup_timer.getAsInt() * 3600D * 1000D);
+        return (long) (backup_timer.getAsDouble() * 3600D * 1000D);
     }
 }


### PR DESCRIPTION
Fixes #173.
Not tested.