### PR TITLE
Fixed ClaimedChunkStorage.canPlayerInteract

### DIFF
--- a/src/main/java/com/feed_the_beast/ftbu/api_impl/ClaimedChunkStorage.java
+++ b/src/main/java/com/feed_the_beast/ftbu/api_impl/ClaimedChunkStorage.java
@@ -133,7 +133,7 @@ public enum ClaimedChunkStorage implements IClaimedChunkStorage, INBTSerializabl
             return true;
         }*/
 
-        return team.hasStatus(player, EnumTeamStatus.ALLY);
+        return team.hasStatus(player, EnumTeamStatus.ALLY) || team.hasStatus(player, EnumTeamStatus.MEMBER) || team.hasStatus(player, EnumTeamStatus.OWNER);
     }
 
     @Override


### PR DESCRIPTION
Fixed ClaimedChunkStorage to return true for team allies, members, and owner for canPlayerInteract. This is in response to #249 