### PR TITLE
Fix onEntityAttacked using getEntity not getTarget

### DIFF
--- a/src/main/java/com/feed_the_beast/ftbu/handlers/FTBUPlayerEventHandler.java
+++ b/src/main/java/com/feed_the_beast/ftbu/handlers/FTBUPlayerEventHandler.java
@@ -98,7 +98,7 @@ public class FTBUPlayerEventHandler
 	{
 		EntityPlayer player = event.getEntityPlayer();
 
-		if (player instanceof EntityPlayerMP && !ClaimedChunks.get().canPlayerAttackEntity((EntityPlayerMP) player, event.getEntity()))
+		if (player instanceof EntityPlayerMP && !ClaimedChunks.get().canPlayerAttackEntity((EntityPlayerMP) player, event.getTarget()))
 		{
 			event.setCanceled(true);
 		}


### PR DESCRIPTION
I believe event.getEntity() in your ```AttackEntityEvent``` handler should be [```event.getTarget()```](https://github.com/MinecraftForge/MinecraftForge/blob/b15269fde504dbe8837a540202a0947c1a5b3e62/src/main/java/net/minecraftforge/event/entity/player/AttackEntityEvent.java#L51)  as otherwise ```ClaimedChunks.get().canPlayerAttackEntity(...)``` is passed the player doing the attacking twice, so [this if branch](https://github.com/LatvianModder/FTBUtilities/blob/d4934b689dd8c0eb2d2f3f688c054e910ce05ad6/src/main/java/com/feed_the_beast/ftbu/data/ClaimedChunks.java#L412) is always run as the entity is always a player, and pvp1 & pvp2 are always identical.

I found this due to a member of on my Server disabling enablePVP in there client settings and then couldn't hit any entity in the world. 