### PR TITLE
Add FTBLib as submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "FTBLib"]
+	path = FTBLib
+	url = git@github.com:LatvianModder/FTBLib.git

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ repositories {
 }
 
 dependencies {
-	deobfCompile "com.feed_the_beast.mods:FTBLib:${ftblib_version}"
+    compile project(':FTBLib')
 	deobfProvided "me.ichun.mods.ichunutil:iChunUtil:${ichunutil_version}:api"
 	provided "info.journeymap:journeymap-api:${journeymap_version}"
 	deobfProvided "mod.chiselsandbits:chiselsandbits:${chiselsandbits_version}:api"

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,6 @@ mc_version=1.12.2
 curseforge_id=237102
 forge_version=14.23.3.2697
 mappings_version=snapshot_20180517
-ftblib_version=5.+
 ichunutil_version=1.12.2-7.1.4
 journeymap_version=1.12-2.0-SNAPSHOT
 chiselsandbits_version=13.0.79

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+include 'FTBLib'


### PR DESCRIPTION
It's quite often that FTBUtilities uses newest feature from FTBLib. We can't compile FTBUtilities until the new version FTBLib artifact uploaded.
We can add FTBLib as submodule so we can just run `git submodule update` to get latest FTBLib source and compile along with FTBUtilities.

BTW, I found that by enabling multi project on gradle. Tasks with same name from two project will execute together. For example: `./gradlew runClient` will launch minecraft twice. To prevent this behavior, you will need to specify project e.g: `./gradlew :runClient` or `./gradlew FTBLib:runClient`