### PR TITLE
Only abort teleport if health is lost during wait

### DIFF
--- a/src/main/java/com/feed_the_beast/ftbutilities/data/FTBUtilitiesPlayerData.java
+++ b/src/main/java/com/feed_the_beast/ftbutilities/data/FTBUtilitiesPlayerData.java
@@ -107,7 +107,7 @@ public class FTBUtilitiesPlayerData implements INBTSerializable<NBTTagCompound>,
 		@Override
 		public void execute(Universe universe)
 		{
-			if (!startPos.equalsPos(new BlockDimPos(player)) || startHP != player.getHealth())
+			if (!startPos.equalsPos(new BlockDimPos(player)) || startHP > player.getHealth())
 			{
 				player.sendStatusMessage(StringUtils.color(FTBLib.lang(player, "stand_still_failed"), TextFormatting.RED), true);
 			}


### PR DESCRIPTION
Having to stand still for 5 second is usually a good time to eat, which then leads to health regen and the teleport to be cancelled.

Instead don't abort the teleport if health is gained, only if health is lost.